### PR TITLE
Implement automated Titanic pipeline agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+__pycache__/
+*.pyc
+*.pyo
+*.egg-info/
+.build/
+.venv/
+.env/
+.cache/
+.agent_tmp/
+.agent_logs/
+.envrc
+.DS_Store
+.idea/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,57 @@
-readme
+# AutoKaggler Titanic Pipeline
+
+AutoKaggler is a self-initialising agent that automates the Kaggle Titanic tutorial
+workflow. It downloads (or falls back to a bundled sample of) the dataset, trains a
+reproducible machine learning model, evaluates it with cross-validation, and emits a
+submission file – all while respecting the JSON in/out contract defined in
+[`AGENTS.md`](AGENTS.md).
+
+## Features
+
+* 🔁 **Self-initialisation** – runtime directories and environment defaults are
+  created automatically.
+* 🧠 **Profile aware** – switch between `fast` (logistic regression) and `power`
+  (random forest) profiles.
+* 🔐 **Safe fallbacks** – if Kaggle downloads are unavailable the agent uses an
+  offline-friendly synthetic dataset.
+* 🧾 **Structured I/O** – accepts `TaskInput` JSON and returns `AgentResult`
+  JSON with the required `#KGNINJA` tag.
+* 🧪 **Reproducible** – deterministic seeds, cached assets, and logged runs.
+
+## Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+## Usage
+
+Run the agent by piping a JSON payload to `python -m autokaggler`:
+
+```bash
+echo '{"profile": "fast", "data_source": "auto"}' | python -m autokaggler
+```
+
+The command prints a JSON object describing the outcome and leaves artefacts in
+`.agent_tmp/` and logs in `.agent_logs/`.
+
+### Kaggle credentials
+
+To work with the real competition data ensure the Kaggle API credentials are
+available via environment variables or `~/.kaggle/kaggle.json`. The agent will
+attempt to download the dataset on the first run and reuse the cached copy on
+subsequent runs.
+
+## Development
+
+Install the optional test dependencies and run the test suite:
+
+```bash
+pip install -e .[test]
+pytest
+```
+
+The repository also contains a synthetic dataset in `data/sample/` used for tests
+and offline development.

--- a/data/sample/schema.json
+++ b/data/sample/schema.json
@@ -1,0 +1,17 @@
+{
+  "description": "Synthetic sample of the Kaggle Titanic dataset for offline development.",
+  "features": {
+    "PassengerId": "Unique identifier for each passenger",
+    "Survived": "Target label indicating survival (1) or not (0)",
+    "Pclass": "Ticket class (1st, 2nd, 3rd)",
+    "Name": "Passenger name",
+    "Sex": "Passenger gender",
+    "Age": "Passenger age in years",
+    "SibSp": "Number of siblings/spouses aboard",
+    "Parch": "Number of parents/children aboard",
+    "Ticket": "Ticket number",
+    "Fare": "Passenger fare",
+    "Cabin": "Cabin identifier",
+    "Embarked": "Port of embarkation"
+  }
+}

--- a/data/sample/test.csv
+++ b/data/sample/test.csv
@@ -1,0 +1,11 @@
+PassengerId,Pclass,Name,Sex,Age,SibSp,Parch,Ticket,Fare,Cabin,Embarked
+892,3,"Kelly, Mr. James",male,34.5,0,0,330911,7.8292,,Q
+893,3,"Wilkes, Mrs. James (Ellen Needs)",female,47,1,0,363272,7,,S
+894,2,"Myles, Mr. Thomas Francis",male,62,0,0,240276,9.6875,,Q
+895,3,"Wirz, Mr. Albert",male,27,0,0,315154,8.6625,,S
+896,3,"Hirvonen, Mrs. Alexander (Helga E Lindqvist)",female,22,1,1,3101298,12.2875,,S
+897,3,"Svensson, Mr. Johan Cervin",male,14,0,0,7538,9.225,,S
+898,3,"Connolly, Miss. Kate",female,30,0,0,330972,7.6292,,Q
+899,2,"Caldwell, Mr. Albert Francis",male,26,1,1,248738,29,,S
+900,3,"Abrahim, Mrs. Joseph (Sophie Halaut Easu)",female,18,0,0,2657,7.2292,,C
+901,3,"Davies, Mr. John Samuel",male,,0,0,A/4 48871,7.8958,,S

--- a/data/sample/train.csv
+++ b/data/sample/train.csv
@@ -1,0 +1,17 @@
+PassengerId,Survived,Pclass,Name,Sex,Age,SibSp,Parch,Ticket,Fare,Cabin,Embarked
+1,0,3,"Braund, Mr. Owen Harris",male,22,1,0,A/5 21171,7.25,,S
+2,1,1,"Cumings, Mrs. John Bradley (Florence Briggs Thayer)",female,38,1,0,PC 17599,71.2833,C85,C
+3,1,3,"Heikkinen, Miss. Laina",female,26,0,0,STON/O2. 3101282,7.925,,S
+4,1,1,"Futrelle, Mrs. Jacques Heath (Lily May Peel)",female,35,1,0,113803,53.1,C123,S
+5,0,3,"Allen, Mr. William Henry",male,35,0,0,373450,8.05,,S
+6,0,3,"Moran, Mr. James",male,,0,0,330877,8.4583,,Q
+7,0,1,"McCarthy, Mr. Timothy J",male,54,0,0,17463,51.8625,E46,S
+8,0,3,"Palsson, Master. Gosta Leonard",male,2,3,1,349909,21.075,,S
+9,1,3,"Johnson, Mrs. Oscar W (Elisabeth Vilhelmina Berg)",female,27,0,2,347742,11.1333,,S
+10,1,2,"Nasser, Mrs. Nicholas (Adele Achem)",female,14,1,0,237736,30.0708,,C
+11,1,3,"Sandstrom, Miss. Marguerite Rut",female,4,1,1,PP 9549,16.7,G6,S
+12,0,1,"Bonnell, Miss. Elizabeth",female,58,0,0,113783,26.55,C103,S
+13,0,3,"Saundercock, Mr. William Henry",male,20,0,0,A/5. 2151,8.05,,S
+14,1,3,"Andersson, Mr. Anders Johan",male,39,1,5,347082,31.275,,S
+15,0,2,"Vestrom, Miss. Hulda Amanda Adolfina",female,14,0,0,350406,7.8542,,S
+16,1,3,"Hewlett, Mrs. (Mary D Kingcome) ",female,55,0,0,248706,16,,S

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,28 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "autokaggler"
+version = "0.1.0"
+description = "Automated pipeline for Kaggle Titanic tutorial"
+authors = [{name = "AutoKaggler"}]
+readme = "README.md"
+requires-python = ">=3.9"
+dependencies = [
+    "pandas>=1.5",
+    "numpy>=1.23",
+    "scikit-learn>=1.1",
+    "kaggle>=1.5.13",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=7.0",
+]
+
+[project.urls]
+Homepage = "https://www.kaggle.com/competitions/titanic"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/autokaggler/__init__.py
+++ b/src/autokaggler/__init__.py
@@ -1,0 +1,5 @@
+"""AutoKaggler package for automating Kaggle Titanic tutorial pipeline."""
+
+from .agent import main
+
+__all__ = ["main"]

--- a/src/autokaggler/__main__.py
+++ b/src/autokaggler/__main__.py
@@ -1,0 +1,6 @@
+"""Module entry point for running the AutoKaggler agent via ``python -m autokaggler``."""
+
+from .agent import main
+
+if __name__ == "__main__":
+    main()

--- a/src/autokaggler/agent.py
+++ b/src/autokaggler/agent.py
@@ -1,0 +1,187 @@
+"""Core agent implementation orchestrating the AutoKaggler pipeline."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import traceback
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from .data_manager import DataManager
+from .pipeline import TitanicPipeline, TitanicPipelineResult
+
+RUNTIME_DIRS = [Path(".agent_tmp"), Path(".agent_logs")]
+DEFAULT_PROFILE = "fast"
+TAG = "#KGNINJA"
+
+
+@dataclass
+class TaskInput:
+    """Declarative configuration for a pipeline execution."""
+
+    profile: Optional[str] = None
+    force_download: bool = False
+    data_source: str = "auto"
+    random_seed: int = 42
+    submission_name: Optional[str] = None
+    notes: Optional[str] = None
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class AgentResult:
+    """Structured response produced by the agent."""
+
+    ok: bool
+    meta: Dict[str, Any]
+    result: Optional[Dict[str, Any]] = None
+    error: Optional[str] = None
+
+
+def bootstrap() -> None:
+    """Prepare runtime directories and default environment."""
+
+    for directory in RUNTIME_DIRS:
+        directory.mkdir(exist_ok=True)
+    os.environ.setdefault("PROFILE", DEFAULT_PROFILE)
+
+
+def load_task_input(raw: str) -> TaskInput:
+    """Deserialize ``TaskInput`` from raw JSON."""
+
+    if not raw.strip():
+        payload: Dict[str, Any] = {}
+    else:
+        payload = json.loads(raw)
+    extra = {k: v for k, v in payload.items() if k not in TaskInput.__dataclass_fields__}
+    params = {k: payload.get(k) for k in TaskInput.__dataclass_fields__ if k != "extra"}
+    task_input = TaskInput(**params)  # type: ignore[arg-type]
+    task_input.extra.update(extra)
+    return task_input
+
+
+def configure_logging(run_id: str) -> Path:
+    """Initialise logging infrastructure for the current run."""
+
+    log_path = RUNTIME_DIRS[1] / f"run-{run_id}.log"
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        handlers=[
+            logging.FileHandler(log_path, mode="w", encoding="utf-8"),
+            logging.StreamHandler(sys.stderr),
+        ],
+    )
+    logging.info("Logging initialised for run %s", run_id)
+    return log_path
+
+
+def resolve_profile(task_input: TaskInput) -> str:
+    """Determine which profile to run based on input and environment."""
+
+    profile = task_input.profile or os.environ.get("PROFILE", DEFAULT_PROFILE)
+    if profile not in {"fast", "power"}:
+        logging.warning("Unknown profile '%s'; falling back to default '%s'", profile, DEFAULT_PROFILE)
+        profile = DEFAULT_PROFILE
+    os.environ["PROFILE"] = profile
+    return profile
+
+
+def run_agent(task_input: TaskInput, run_id: str) -> TitanicPipelineResult:
+    """Execute the Titanic pipeline."""
+
+    data_manager = DataManager(cache_dir=RUNTIME_DIRS[0])
+    train_df, test_df, data_meta = data_manager.prepare_datasets(
+        prefer_source=task_input.data_source,
+        force_download=task_input.force_download,
+    )
+
+    profile = resolve_profile(task_input)
+    pipeline = TitanicPipeline(profile=profile, random_seed=task_input.random_seed)
+    submission_name = task_input.submission_name or f"submission-{run_id}.csv"
+
+    result = pipeline.run(
+        train_df=train_df,
+        test_df=test_df,
+        submission_name=submission_name,
+        output_dir=data_manager.submission_dir,
+        notes=task_input.notes,
+        data_meta=data_meta,
+    )
+    return result
+
+
+def build_success_result(run_id: str, log_path: Path, result: TitanicPipelineResult, profile: str) -> AgentResult:
+    """Construct a success payload."""
+
+    meta = {
+        "profile": profile,
+        "run_id": run_id,
+        "tags": [TAG],
+        "log_file": str(log_path),
+        "cache_dir": str(RUNTIME_DIRS[0]),
+    }
+    payload = {
+        "cv_mean_accuracy": result.cv_mean,
+        "cv_std": result.cv_std,
+        "model_name": result.model_name,
+        "submission_path": result.submission_path,
+        "data_source": result.data_source,
+        "notes": result.notes,
+    }
+    return AgentResult(ok=True, meta=meta, result=payload)
+
+
+def build_failure_result(run_id: str, log_path: Path, exc: BaseException) -> AgentResult:
+    """Construct a failure payload with diagnostic information."""
+
+    meta = {
+        "profile": os.environ.get("PROFILE", DEFAULT_PROFILE),
+        "run_id": run_id,
+        "tags": [TAG],
+        "log_file": str(log_path),
+        "cache_dir": str(RUNTIME_DIRS[0]),
+    }
+    error = "{}: {}".format(type(exc).__name__, exc)
+    logging.error("Pipeline failed: %s", error)
+    logging.debug("Traceback:\n%s", traceback.format_exc())
+    return AgentResult(ok=False, meta=meta, error=error)
+
+
+def serialise_result(result: AgentResult) -> str:
+    """Serialise the agent result to JSON."""
+
+    return json.dumps(result.__dict__, ensure_ascii=False, default=str)
+
+
+def main() -> None:
+    """Entry point for executing the AutoKaggler agent."""
+
+    bootstrap()
+    run_id = datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+    log_path = configure_logging(run_id)
+
+    raw_input = sys.stdin.read()
+    try:
+        task_input = load_task_input(raw_input)
+    except json.JSONDecodeError as exc:
+        result = build_failure_result(run_id, log_path, exc)
+        print(serialise_result(result))
+        return
+
+    try:
+        profile = resolve_profile(task_input)
+        pipeline_result = run_agent(task_input, run_id)
+        result = build_success_result(run_id, log_path, pipeline_result, profile)
+    except Exception as exc:  # pylint: disable=broad-except
+        result = build_failure_result(run_id, log_path, exc)
+    print(serialise_result(result))
+
+
+if __name__ == "__main__":  # pragma: no cover - handled via __main__
+    main()

--- a/src/autokaggler/data_manager.py
+++ b/src/autokaggler/data_manager.py
@@ -1,0 +1,134 @@
+"""Dataset management utilities for the AutoKaggler agent."""
+
+from __future__ import annotations
+
+import json
+import logging
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Tuple
+
+import pandas as pd
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SAMPLE_DATA_DIR = PROJECT_ROOT / "data" / "sample"
+
+
+@dataclass
+class DataMeta:
+    """Metadata describing the dataset that was loaded."""
+
+    source: str
+    location: str
+    additional: Dict[str, str]
+
+
+class DataManager:
+    """Handle retrieval and caching of Titanic datasets."""
+
+    def __init__(self, cache_dir: Path | str) -> None:
+        self.cache_dir = Path(cache_dir)
+        self.data_dir = self.cache_dir / "titanic"
+        self.submission_dir = self.cache_dir / "submissions"
+        self.data_dir.mkdir(parents=True, exist_ok=True)
+        self.submission_dir.mkdir(parents=True, exist_ok=True)
+
+    def prepare_datasets(
+        self, prefer_source: str = "auto", force_download: bool = False
+    ) -> Tuple[pd.DataFrame, pd.DataFrame, DataMeta]:
+        """Return Titanic train and test dataframes plus metadata.
+
+        Parameters
+        ----------
+        prefer_source:
+            ``"auto"`` will attempt Kaggle download first and fallback to the
+            bundled sample dataset. ``"kaggle"`` forces Kaggle (raising on
+            failure) and ``"sample"`` forces the bundled dataset.
+        force_download:
+            When ``True`` any cached Kaggle download is ignored and files are
+            re-fetched.
+        """
+
+        prefer_source = prefer_source or "auto"
+        if prefer_source not in {"auto", "kaggle", "sample"}:
+            logging.warning("Unknown data source '%s'; defaulting to 'auto'", prefer_source)
+            prefer_source = "auto"
+
+        if prefer_source == "sample":
+            return self._load_sample()
+
+        if prefer_source in {"auto", "kaggle"}:
+            try:
+                return self._load_kaggle(force_download=force_download)
+            except Exception as exc:  # pylint: disable=broad-except
+                if prefer_source == "kaggle":
+                    logging.error("Kaggle download requested but failed: %s", exc)
+                    raise
+                logging.warning(
+                    "Falling back to bundled sample dataset due to Kaggle error: %s", exc
+                )
+        return self._load_sample()
+
+    def _load_kaggle(self, force_download: bool = False) -> Tuple[pd.DataFrame, pd.DataFrame, DataMeta]:
+        """Download from Kaggle and return the datasets."""
+
+        train_path = self.data_dir / "train.csv"
+        test_path = self.data_dir / "test.csv"
+        if force_download or not train_path.exists() or not test_path.exists():
+            self._download_from_kaggle()
+        train_df = pd.read_csv(train_path)
+        test_df = pd.read_csv(test_path)
+        meta = DataMeta(
+            source="kaggle",
+            location=str(self.data_dir),
+            additional={"ref": "https://www.kaggle.com/competitions/titanic"},
+        )
+        return train_df, test_df, meta
+
+    def _download_from_kaggle(self) -> None:
+        """Use the Kaggle API to download the Titanic dataset."""
+
+        logging.info("Attempting to download Titanic dataset from Kaggle")
+        try:
+            from kaggle.api.kaggle_api_extended import KaggleApi
+        except ImportError as exc:  # pragma: no cover - handled by dependency management
+            raise RuntimeError("Kaggle package is required to download datasets") from exc
+
+        api = KaggleApi()
+        api.authenticate()
+
+        archive_path = self.data_dir / "titanic.zip"
+        if archive_path.exists():
+            archive_path.unlink()
+        api.competition_download_files("titanic", path=str(self.data_dir), quiet=True)
+
+        with zipfile.ZipFile(archive_path, "r") as zf:
+            zf.extractall(self.data_dir)
+        archive_path.unlink(missing_ok=True)
+        logging.info("Titanic dataset downloaded to %s", self.data_dir)
+
+    def _load_sample(self) -> Tuple[pd.DataFrame, pd.DataFrame, DataMeta]:
+        """Load the bundled sample dataset for offline usage."""
+
+        train_path = SAMPLE_DATA_DIR / "train.csv"
+        test_path = SAMPLE_DATA_DIR / "test.csv"
+        schema_path = SAMPLE_DATA_DIR / "schema.json"
+        if not train_path.exists() or not test_path.exists():
+            raise FileNotFoundError("Sample dataset is missing from the repository")
+
+        train_df = pd.read_csv(train_path)
+        test_df = pd.read_csv(test_path)
+        additional: Dict[str, str] = {}
+        if schema_path.exists():
+            additional["schema"] = json.dumps(json.loads(schema_path.read_text(encoding="utf-8")))
+        meta = DataMeta(
+            source="sample",
+            location=str(SAMPLE_DATA_DIR),
+            additional=additional,
+        )
+        logging.info("Loaded bundled sample dataset from %s", SAMPLE_DATA_DIR)
+        return train_df, test_df, meta
+
+
+__all__ = ["DataManager", "DataMeta"]

--- a/src/autokaggler/pipeline.py
+++ b/src/autokaggler/pipeline.py
@@ -1,0 +1,159 @@
+"""Machine learning pipeline implementations for the Kaggle Titanic challenge."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+from sklearn.compose import ColumnTransformer
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.impute import SimpleImputer
+from sklearn.linear_model import LogisticRegression
+from sklearn.model_selection import StratifiedKFold, cross_val_score
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import OneHotEncoder, StandardScaler
+
+from .data_manager import DataMeta
+
+FEATURE_COLUMNS = ["Pclass", "Sex", "Age", "SibSp", "Parch", "Fare", "Embarked"]
+TARGET_COLUMN = "Survived"
+
+
+@dataclass
+class TitanicPipelineResult:
+    """Summary of a Titanic pipeline execution."""
+
+    cv_mean: float
+    cv_std: float
+    model_name: str
+    submission_path: str
+    data_source: str
+    notes: Optional[str]
+
+
+class TitanicPipeline:
+    """Configurable Titanic modelling pipeline."""
+
+    def __init__(self, profile: str = "fast", random_seed: int = 42) -> None:
+        self.profile = profile
+        self.random_seed = random_seed
+        self._model_name = self._select_model_name(profile)
+
+    @staticmethod
+    def _select_model_name(profile: str) -> str:
+        if profile == "power":
+            return "RandomForestClassifier"
+        return "LogisticRegression"
+
+    def _build_model(self) -> Pipeline:
+        numeric_features = ["Age", "SibSp", "Parch", "Fare"]
+        categorical_features = ["Pclass", "Sex", "Embarked"]
+
+        numeric_transformer = Pipeline(
+            steps=[
+                ("imputer", SimpleImputer(strategy="median")),
+                ("scaler", StandardScaler()),
+            ]
+        )
+        categorical_transformer = Pipeline(
+            steps=[
+                ("imputer", SimpleImputer(strategy="most_frequent")),
+                ("encoder", OneHotEncoder(handle_unknown="ignore")),
+            ]
+        )
+        preprocessor = ColumnTransformer(
+            transformers=[
+                ("num", numeric_transformer, numeric_features),
+                ("cat", categorical_transformer, categorical_features),
+            ]
+        )
+
+        if self.profile == "power":
+            model = RandomForestClassifier(
+                n_estimators=400,
+                max_depth=None,
+                random_state=self.random_seed,
+                n_jobs=-1,
+                min_samples_split=2,
+            )
+        else:
+            model = LogisticRegression(max_iter=1000, random_state=self.random_seed)
+
+        pipeline = Pipeline(steps=[("preprocess", preprocessor), ("model", model)])
+        return pipeline
+
+    def run(
+        self,
+        train_df: pd.DataFrame,
+        test_df: pd.DataFrame,
+        submission_name: str,
+        output_dir: Path,
+        notes: Optional[str],
+        data_meta: DataMeta,
+    ) -> TitanicPipelineResult:
+        """Train, evaluate and export predictions for the Titanic task."""
+
+        logging.info("Starting Titanic pipeline with profile '%s'", self.profile)
+        np.random.seed(self.random_seed)
+
+        self._validate_dataframe(train_df, is_train=True)
+        self._validate_dataframe(test_df, is_train=False)
+
+        X = train_df[FEATURE_COLUMNS]
+        y = train_df[TARGET_COLUMN]
+
+        estimator = self._build_model()
+
+        cv = StratifiedKFold(n_splits=5, shuffle=True, random_state=self.random_seed)
+        scores = cross_val_score(estimator, X, y, cv=cv, scoring="accuracy")
+        logging.info("Cross-validation accuracy: mean=%.4f std=%.4f", scores.mean(), scores.std())
+
+        estimator.fit(X, y)
+        logging.info("Model '%s' fitted on %d samples", self._model_name, len(train_df))
+
+        submission_df = self._build_submission(estimator, test_df)
+
+        output_dir.mkdir(parents=True, exist_ok=True)
+        submission_path = output_dir / submission_name
+        submission_df.to_csv(submission_path, index=False)
+        logging.info("Submission saved to %s", submission_path)
+
+        note_lines = []
+        if notes:
+            note_lines.append(notes)
+        if data_meta.source == "sample":
+            note_lines.append("Using bundled sample dataset")
+        compiled_notes = " | ".join(note_lines) if note_lines else None
+
+        return TitanicPipelineResult(
+            cv_mean=float(scores.mean()),
+            cv_std=float(scores.std()),
+            model_name=self._model_name,
+            submission_path=str(submission_path),
+            data_source=data_meta.source,
+            notes=compiled_notes,
+        )
+
+    @staticmethod
+    def _build_submission(model: Pipeline, test_df: pd.DataFrame) -> pd.DataFrame:
+        predictions = model.predict(test_df[FEATURE_COLUMNS])
+        submission_df = pd.DataFrame({
+            "PassengerId": test_df["PassengerId"],
+            "Survived": predictions.astype(int),
+        })
+        return submission_df
+
+    @staticmethod
+    def _validate_dataframe(df: pd.DataFrame, *, is_train: bool) -> None:
+        missing_columns = [col for col in FEATURE_COLUMNS if col not in df.columns]
+        if is_train and TARGET_COLUMN not in df.columns:
+            missing_columns.append(TARGET_COLUMN)
+        if missing_columns:
+            raise ValueError(f"Dataset is missing required columns: {missing_columns}")
+
+
+__all__ = ["TitanicPipeline", "TitanicPipelineResult"]

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,46 @@
+"""Tests for the AutoKaggler Titanic pipeline."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from autokaggler.agent import build_success_result
+from autokaggler.data_manager import DataManager
+from autokaggler.pipeline import TitanicPipeline, TitanicPipelineResult
+
+
+def test_pipeline_runs_on_sample_data(tmp_path):
+    manager = DataManager(cache_dir=tmp_path)
+    train_df, test_df, meta = manager.prepare_datasets(prefer_source="sample")
+    pipeline = TitanicPipeline(profile="fast", random_seed=7)
+    result = pipeline.run(
+        train_df=train_df,
+        test_df=test_df,
+        submission_name="test_submission.csv",
+        output_dir=manager.submission_dir,
+        notes="pytest",
+        data_meta=meta,
+    )
+
+    assert 0.0 <= result.cv_mean <= 1.0
+    assert Path(result.submission_path).exists()
+    assert result.data_source == "sample"
+
+
+def test_success_result_contains_required_metadata(tmp_path):
+    dummy_result = TitanicPipelineResult(
+        cv_mean=0.5,
+        cv_std=0.1,
+        model_name="LogisticRegression",
+        submission_path=str(tmp_path / "submission.csv"),
+        data_source="sample",
+        notes=None,
+    )
+    agent_result = build_success_result(
+        run_id="test-run",
+        log_path=tmp_path / "log.txt",
+        result=dummy_result,
+        profile="fast",
+    )
+    assert agent_result.ok is True
+    assert "#KGNINJA" in agent_result.meta["tags"]


### PR DESCRIPTION
## Summary
- introduce an AutoKaggler agent with JSON I/O, profile-aware execution, and structured logging
- add dataset manager with Kaggle download support and bundled sample fallback
- implement the Titanic ML pipeline, packaging metadata, and regression tests using the synthetic dataset

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cba792175883299d90ba6a0d2c80ef